### PR TITLE
Update build status to two columns for each GitHub action in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Persian Data Library is a library that can be convert **Gregorian** (Milady) yea
 
 
 ## Persian Date Public Version
-| Target | Branch | Version | Download link | Total downloads |
-| ------ | ------ | ------ | ------ | ------ |
-| Nuget | master | v1.0.5 | [![NuGet](https://img.shields.io/nuget/v/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![NuGet downloads](https://img.shields.io/nuget/dt/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) |
-| Release | master | v1.0.5 | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | |
+| Target | Branch | Version | Download link | Total downloads | CI Build Status | CD Build Status |
+| ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| Nuget | master | v1.0.5 | [![NuGet](https://img.shields.io/nuget/v/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![NuGet downloads](https://img.shields.io/nuget/dt/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/ci.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/cd.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) |
+| Release | master | v1.0.5 | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/ci.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/ci.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/cd.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) |
 
 ## Cross Platform
 


### PR DESCRIPTION
Update the `README.md` file to display build status in two columns for each GitHub action.

- **Persian Date Public Version Section**:
  - Add columns for CI and CD build status.
  - Update CI build status badge to use `ci.yml`.
  - Add CD build status badge using `cd.yml`.

