### PR TITLE
Fix CD error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,14 @@ jobs:
       id: get_version
       run: echo "::set-output name=version::$(dotnet run --project ./PrsianDate/PrsianDate.csproj --configuration Release --no-build --no-restore)"
 
+    - name: Delete existing tag if it exists
+      id: delete_tag
+      run: |
+        if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+          git tag -d "v${{ steps.get_version.outputs.version }}"
+          git push --delete origin "v${{ steps.get_version.outputs.version }}"
+        fi
+
     - name: Create GitHub release
       id: create_release
       uses: actions/create-release@v1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The CI pipeline is defined in `.github/workflows/ci.yml` and uses `macos-latest`
 
 ## CD Pipeline
 
-The CD pipeline is defined in `.github/workflows/cd.yml` and uses `macos-latest` as the VM image. It restores NuGet packages, builds the solution, runs tests, and publishes the NuGet package. The pipeline installs .NET version 8.0.x to ensure compatibility with all targeted frameworks.
+The CD pipeline is defined in `.github/workflows/cd.yml` and uses `macos-latest` as the VM image. It restores NuGet packages, builds the solution, runs tests, and publishes the NuGet package. The pipeline installs .NET version 8.0.x to ensure compatibility with all targeted frameworks. Additionally, it includes a step to delete existing tags if they already exist before creating a new release to avoid the 'Validation Failed: already_exists' error.
 
 ## Developer [![Twitter Follow](https://img.shields.io/twitter/follow/hootanht?style=social)](https://twitter.com/hootanht)
 


### PR DESCRIPTION
Add a step to delete existing tags before creating a new release to avoid the 'Validation Failed: already_exists' error.

* **.github/workflows/cd.yml**
  - Add a new step to delete the existing tag if it already exists before creating a new release.
  - Use the `git tag -d` and `git push --delete origin` commands to delete the existing tag.

* **README.md**
  - Update the CD pipeline description to include the new step for deleting existing tags if they already exist before creating a new release.

