### PR TITLE
Fix CD error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,6 +43,17 @@ jobs:
           git tag -d "v${{ steps.get_version.outputs.version }}"
           git push --delete origin "v${{ steps.get_version.outputs.version }}"
         fi
+      continue-on-error: true
+
+    - name: Check if tag deletion was successful
+      id: check_tag_deletion
+      run: |
+        if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+          echo "Tag deletion failed"
+          exit 1
+        else
+          echo "Tag deletion successful"
+        fi
 
     - name: Create GitHub release
       id: create_release

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The CI pipeline is defined in `.github/workflows/ci.yml` and uses `macos-latest`
 
 ## CD Pipeline
 
-The CD pipeline is defined in `.github/workflows/cd.yml` and uses `macos-latest` as the VM image. It restores NuGet packages, builds the solution, runs tests, and publishes the NuGet package. The pipeline installs .NET version 8.0.x to ensure compatibility with all targeted frameworks. Additionally, it includes a step to delete existing tags if they already exist before creating a new release to avoid the 'Validation Failed: already_exists' error.
+The CD pipeline is defined in `.github/workflows/cd.yml` and uses `macos-latest` as the VM image. It restores NuGet packages, builds the solution, runs tests, and publishes the NuGet package. The pipeline installs .NET version 8.0.x to ensure compatibility with all targeted frameworks. Additionally, it includes a step to delete existing tags if they already exist before creating a new release to avoid the 'Validation Failed: already_exists' error. The step now handles the case where the tag deletion fails and ensures the deletion step successfully removes the existing tag before proceeding to create a new release.
 
 ## Developer [![Twitter Follow](https://img.shields.io/twitter/follow/hootanht?style=social)](https://twitter.com/hootanht)
 


### PR DESCRIPTION
Update the CD pipeline to handle existing tag deletion failures and ensure successful tag deletion before creating a new release.

* **README.md**
  - Update the "CD Pipeline" section to mention the improved handling of existing tags and ensuring successful tag deletion before creating a new release.

* **.github/workflows/cd.yml**
  - Add `continue-on-error: true` to the `Delete existing tag if it exists` step to handle tag deletion failures.
  - Add a new step `Check if tag deletion was successful` to verify if the tag deletion was successful before proceeding to create a new release.

