### PR TITLE
Update PersianDate.csproj to include missing tags

### DIFF
--- a/PersianDate/PersianDate.csproj
+++ b/PersianDate/PersianDate.csproj
@@ -25,6 +25,9 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>
 		<ReadmeFile>README.md</ReadmeFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<EnablePackageValidation>true</EnablePackageValidation>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -36,6 +39,10 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MinVer" Version="6.0.0">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	  <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>


### PR DESCRIPTION
Add missing properties and package references to `PersianDate/PersianDate.csproj`.

* **PropertyGroup:**
  - Add `<PackageReadmeFile>README.md</PackageReadmeFile>`
  - Add `<NoWarn>$(NoWarn);CS1591</NoWarn>`
  - Add `<EnablePackageValidation>true</EnablePackageValidation>`

* **ItemGroup:**
  - Add `<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">`
  - Add `<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>`
  - Add `<PrivateAssets>all</PrivateAssets>`

