### PR TITLE
Update .nuspec version to 1.0.5 in CD

### DIFF
--- a/PersianDate/PersianDate.csproj
+++ b/PersianDate/PersianDate.csproj
@@ -44,11 +44,11 @@
 	<ItemGroup>
 	  <PackageReference Include="MinVer" Version="6.0.0">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	    <PrivateAssets>all</PrivateAssets>
+	    <PrivateAssets>all</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	    <PrivateAssets>all</PrivateAssets>
+	    <PrivateAssets>all</IncludeAssets>
 	  </PackageReference>
 	</ItemGroup>
 


### PR DESCRIPTION
Update the `<PrivateAssets>` element in `PersianDate/PersianDate.csproj` to use the correct closing tag.

* **PersianDate/PersianDate.csproj**
  - Change `<PrivateAssets>` to `<PrivateAssets>all</IncludeAssets>` for `MinVer` and `DotNet.ReproducibleBuilds` package references.

