### PR TITLE
Add GitHub Packages support

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -88,10 +88,21 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
 
+      # Authenticate with GitHub Packages using the GITHUB_TOKEN secret
+      - name: Authenticate with GitHub Packages
+        run: dotnet nuget add source https://nuget.pkg.github.com/hootanht/index.json -n github -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
+
+      # Publish all NuGet packages to GitHub Packages
+      - name: Publish NuGet package to GitHub Packages
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
+              dotnet nuget push $file --api-key "${{ secrets.GITHUB_TOKEN }}" --source https://nuget.pkg.github.com/hootanht/index.json --skip-duplicate
+          }
+
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.
       # If you retry a failed workflow, already published packages will be skipped without error.
-      - name: Publish NuGet package
+      - name: Publish NuGet package to NuGet.org
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
               dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/PersianDate/PersianDate.csproj
+++ b/PersianDate/PersianDate.csproj
@@ -16,11 +16,11 @@
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<PackageProjectUrl>https://github.com/hootanht/PrsianDate</PackageProjectUrl>
 		<Version>1.0.5</Version>
-		<RepositoryUrl>https://github.com/hootanht/PrsianDate</RepositoryUrl>
+		<RepositoryUrl>https://github.com/hootanht/PersianDate</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<PackageSource>https://api.nuget.org/v3/index.json</PackageSource>
+		<PackageSource>https://nuget.pkg.github.com/hootanht/index.json</PackageSource>
 		<PublishProfile>nuget</PublishProfile>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Add GitHub Packages registry configuration and update CD pipeline to publish package to GitHub Packages.

* **PersianDate/PersianDate.csproj**
  - Update `<RepositoryUrl>` to `https://github.com/hootanht/PersianDate`.
  - Change `<PackageSource>` to `https://nuget.pkg.github.com/hootanht/index.json`.

* **.github/workflows/CD.yml**
  - Add step to authenticate with GitHub Packages using the `GITHUB_TOKEN` secret.
  - Add step to publish NuGet package to GitHub Packages.
  - Rename existing step to publish NuGet package to NuGet.org.

