### PR TITLE
Update version to 1.0.6 and add GitHub release

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -106,4 +106,44 @@ jobs:
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
               dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
-          }
+
+  create_github_release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: macos-latest
+    needs: [ deploy ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
+      - name: Get version from csproj
+        id: get_version
+        run: |
+          $version = (Get-Content -Path PersianDate/PersianDate.csproj) -match '<Version>(.*)</Version>' | Out-Null; $matches[1]
+          echo "::set-output name=VERSION::$version"
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get_version.outputs.VERSION }}
+          release_name: Release ${{ steps.get_version.outputs.VERSION }}
+          body: |
+            ## What's Changed
+            ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.NuGetDirectory }}/*.nupkg
+          asset_name: PersianDateShamsi.${{ steps.get_version.outputs.VERSION }}.nupkg
+          asset_content_type: application/zip

--- a/PersianDate/PersianDate.csproj
+++ b/PersianDate/PersianDate.csproj
@@ -15,7 +15,7 @@
 		<PackageReleaseNotes>Add support for .Net 8.0</PackageReleaseNotes>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<PackageProjectUrl>https://github.com/hootanht/PrsianDate</PackageProjectUrl>
-		<Version>1.0.5</Version>
+		<Version>1.0.6</Version>
 		<RepositoryUrl>https://github.com/hootanht/PersianDate</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<ImplicitUsings>disable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Persian Data Library is a library that can be convert **Gregorian** (Milady) yea
 ## Persian Date Public Version
 | Target | Branch | Version | Download link | Total downloads | CI Build Status | CD Build Status |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| Nuget | master | v1.0.5 | [![NuGet](https://img.shields.io/nuget/v/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![NuGet downloads](https://img.shields.io/nuget/dt/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CI.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CD.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) |
+| Nuget | master | v1.0.6 | [![NuGet](https://img.shields.io/nuget/v/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![NuGet downloads](https://img.shields.io/nuget/dt/PersianDateShamsi.svg)](https://www.nuget.org/packages/PersianDateShamsi) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CI.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CD.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) |
 | Release | master | v1.0.5 | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CI.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CI.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) | [![Build Status](https://github.com/hootanht/PersianDate/actions/workflows/CD.yml/badge.svg)](https://github.com/hootanht/PersianDate/actions) |
 
 ## Cross Platform
@@ -59,7 +59,7 @@ Extension Method For DateTime
 ```
 
 ## Version changes
-Version 1.0.5
+Version 1.0.6
 
 -Add support for .Net 8.0
 


### PR DESCRIPTION
Update the version from 1.0.5 to 1.0.6 in relevant files and add a step to create a GitHub release after deploying to NuGet.

* **PersianDate/PersianDate.csproj**
  - Update the `<Version>` element to `1.0.6`.

* **README.md**
  - Update the version in the "Persian Date Public Version" table to `v1.0.6`.
  - Update the version in the "Version changes" section to `1.0.6`.

* **.github/workflows/CD.yml**
  - Add a new job `create_github_release` to create a GitHub release with the tag name of the version of the NuGet package.
  - Automatically fill the "What's Changed" section by comparing to the previous release.
  - Upload the NuGet package as a release asset.

