### PR TITLE
Fix CD error

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
               dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
 
   create_github_release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ The CD pipeline is defined in `.github/workflows/CD.yml` and uses `macos-latest`
    ```sh
    dotnet test
    ```
+


### PR DESCRIPTION
Fix the missing closing '}' in the `deploy` job's `foreach` loop in the `.github/workflows/CD.yml` file.

* **.github/workflows/CD.yml**
  - Add a closing '}' at line 100 to fix the missing closing '}' error in the `deploy` job's `foreach` loop.

* **README.md**
  - Add a blank line at the end of the file.

