### PR TITLE
Fix CD error

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Get version from csproj
         id: get_version
         run: |
-          $version = (Get-Content -Path PersianDate/PersianDate.csproj) -match '<Version>(.*)</Version>' | Out-Null; $matches[1]
+          $version = dotnet msbuild -nologo -t:GetVersion -v:q -p:VersionPrefix=1.0.6 -p:VersionSuffix=ci
           echo "::set-output name=VERSION::$version"
 
       - name: Create GitHub Release

--- a/PersianDate/PersianDate.csproj
+++ b/PersianDate/PersianDate.csproj
@@ -30,6 +30,11 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<VersionPrefix>1.0.6</VersionPrefix>
+		<VersionSuffix>ci</VersionSuffix>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<None Include="..\README.md">
 			<Pack>True</Pack>


### PR DESCRIPTION
Update the CD workflow to fix the version extraction error.

* **PersianDate/PersianDate.csproj**
  - Add a new property group with `VersionPrefix` set to `1.0.6` and `VersionSuffix` set to `ci`.

* **.github/workflows/CD.yml**
  - Update the `Get version from csproj` step to use `dotnet msbuild` to extract the version.
  - Replace the existing `run` command with `dotnet msbuild -nologo -t:GetVersion -v:q -p:VersionPrefix=1.0.6 -p:VersionSuffix=ci`.
  - Update the `echo` command to set the `VERSION` output to the extracted version.

